### PR TITLE
Add support for province/state-level timeseries data

### DIFF
--- a/action.js
+++ b/action.js
@@ -15,39 +15,77 @@ const dataPath = path.join(
   "csse_covid_19_data",
   "csse_covid_19_time_series"
 );
-const outputPath = path.join(WORKSPACE, MAIN_REPO, "docs", "timeseries.json");
+const countryOutputPath = path.join(WORKSPACE, MAIN_REPO, "docs", "timeseries.json");
 
 function extract(filename) {
   const csv = fs.readFileSync(path.resolve(dataPath, filename));
   const [headers, ...rows] = parse(csv);
   const [province, country, lat, long, ...dates] = headers;
-  const countList = {};
+  const countryCounts = {};
 
   rows.forEach(([province, country, lat, long, ...counts]) => {
-    countList[country] = countList[country] || {};
+    // if country hasn't been added to countryCounts, add empty obj
+    countryCounts[country] = countryCounts[country] || {mainData: {} };
+    // if province is truthy, add province structure now now
+    if (province) {
+      countryCounts[country].Provinces = countryCounts[country]["Provinces"] || {}
+      countryCounts[country]["Provinces"][province] = {}
+    }      
     dates.forEach((date, i) => {
-      countList[country][date] = countList[country][date] || 0;
-      countList[country][date] += +counts[i];
+      countryCounts[country].mainData[date] = countryCounts[country].mainData[date] || 0;
+      countryCounts[country].mainData[date] += +counts[i];
+      if (province) {
+        countryCounts[country]["Provinces"][province][date] = counts[i];
+      }
     });
   });
-  return [countList, dates];
+  return [countryCounts, dates];
 }
+
+function buildSeries (dates, confirmed, deaths, recovered) {
+  //console.log(confirmed['3/16/20'])
+  //console.log(dates)
+  return dates.map(date => {
+    const [month, day] = date.split("/");
+    
+    return {
+      date: `2020-${month}-${day}`,
+      confirmed: confirmed[date],
+      deaths: deaths[date],
+      recovered: recovered[date]
+    };
+  });
+}
+
 
 const [confirmed, dates] = extract(FILENAME_CONFIRMED);
 const [deaths] = extract(FILENAME_DEATHS);
 const [recovered] = extract(FILENAME_RECOVERED);
 const countries = Object.keys(confirmed);
-const results = {};
+const mainResults = {};
+const provSeries = {};
 countries.forEach(country => {
-  results[country] = dates.map(date => {
-    const [month, day] = date.split("/");
-    return {
-      date: `2020-${month}-${day}`,
-      confirmed: confirmed[country][date],
-      deaths: deaths[country][date],
-      recovered: recovered[country][date]
-    };
-  });
+  let c = confirmed[country].mainData,
+      d = deaths[country].mainData,
+      r = recovered[country].mainData;
+  mainResults[country] = buildSeries(dates, c, d, r);
+  if (confirmed[country].Provinces) {
+    provSeries[country] = {}
+    let provinces = Object.keys(confirmed[country].Provinces)
+    for (p of provinces) {
+      let dp = deaths[country].Provinces[p],
+          cp = confirmed[country].Provinces[p],
+          rp = recovered[country].Provinces[p]
+      provSeries[country][p] = buildSeries(dates, cp, dp, rp);
+    }
+  }
+  
 });
 
-fs.writeFileSync(outputPath, JSON.stringify(results, null, 2));
+fs.writeFileSync(countryOutputPath, JSON.stringify(mainResults, null, 2));
+
+let byProvince = Object.keys(provSeries);
+byProvince.forEach (ctry => {
+  let thisPath = path.join(WORKSPACE, MAIN_REPO, "docs", `provinces-${ctry}.json`);
+  fs.writeFileSync(thisPath, JSON.stringify(provSeries[ctry], null, 2))
+})


### PR DESCRIPTION
- add new function `buildSeries` to extract main parsing logic
- create new files `province-${country}.json` for the relevant
countries

Addresses half of #9