### PR TITLE
Format `date` field of time series

### DIFF
--- a/action.js
+++ b/action.js
@@ -40,7 +40,7 @@ const countries = Object.keys(confirmed);
 const results = {};
 countries.forEach(country => {
   results[country] = dates.map(date => {
-    const [month, day] = date.split("/");
+    const [month, day] = date.split("/").map(x => x.padStart(2, 0));
     return {
       date: `2020-${month}-${day}`,
       confirmed: confirmed[country][date],


### PR DESCRIPTION
Pad the start of the `date` field of time series to ensure the
dates are of the form:

    YYYY-MM-DD

I've tested this on my repo with a per-minute action and it appears to all go through swimmingly.