### PR TITLE
Add .gitignore to prevent node_modules on repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# dependencies
+/node_modules


### PR DESCRIPTION
The purpose is to reduce repository size.